### PR TITLE
Fix JSON encoding error that prevents sending back original execution exception

### DIFF
--- a/lib/GraphQL/Execution.pm
+++ b/lib/GraphQL/Execution.pm
@@ -212,7 +212,9 @@ fun _variables_apply_defaults(
     if ($@) {
       my $error = $@;
       $error =~ s#\s+at.*line\s+\d+\.#.#;
-      die "Variable '\$$_' got invalid value @{[$JSON->canonical->encode($maybe_value)]}.\n$error";
+      # JSON cannot encode scalar references
+      my $jsonable = _coerce_for_error($maybe_value);
+      die "Variable '\$$_' got invalid value @{[$JSON->canonical->encode($jsonable)]}.\n$error";
     }
     ($_ => { value => $parsed_value, type => $opvar_type })
   } keys %$operation_variables };
@@ -612,15 +614,39 @@ fun _get_argument_values(
     if ($@) {
       my $error = $@;
       $error =~ s#\s+at.*line\s+\d+\.#.#;
+      # JSON can't encode scalar references
+      my $jsonable = _coerce_for_error($coerced_values{$name});
       die GraphQL::Error->new(
         message => "Argument '$name' got invalid value"
-          . " @{[$JSON->encode($coerced_values{$name})]}.\nExpected '"
+          . " @{[$JSON->encode($jsonable)]}.\nExpected '"
           . $arg_type->to_string . "'.\n$error",
         nodes => [ $node ],
       );
     }
   }
   \%coerced_values;
+}
+
+fun _coerce_for_error(Any $value) {
+#   my ($value) = @_;
+  
+  my $ret;
+  
+  if ( 'ARRAY' eq ref $value ) {
+    $ret = [
+      map { 'SCALAR' eq ref($_) ? $$_ : $_ } @$value
+    ];
+  }
+  elsif ( 'HASH' eq ref $value ) {
+    $ret = {
+      map { $_ => 'SCALAR' eq ref($value->{$_}) ? ${ $value->{$_} } : $value->{$_} } keys %$value
+    };
+  }
+  else {
+    $ret = $value;
+  }
+  
+  return $ret;
 }
 
 fun _coerce_value(

--- a/lib/GraphQL/Execution.pm
+++ b/lib/GraphQL/Execution.pm
@@ -628,21 +628,12 @@ fun _get_argument_values(
 }
 
 fun _coerce_for_error(Any $value) {
-  my $ret;
-  
-  if ( 'ARRAY' eq ref $value ) {
-    $ret = [
-      map { 'SCALAR' eq ref($_) ? $$_ : $_ } @$value
-    ];
-  }
-  elsif ( 'HASH' eq ref $value ) {
-    $ret = {
-      map { $_ => 'SCALAR' eq ref($value->{$_}) ? ${ $value->{$_} } : $value->{$_} } keys %$value
-    };
-  }
-  else {
-    $ret = $value;
-  }
+  my $ref = ref $value;
+  my $ret = 'SCALAR' eq $ref ? $$value
+          : 'ARRAY'  eq $ref ? [ map { _coerce_for_error($_) } @$value ]
+          : 'HASH'   eq $ref ? { map { $_ => _coerce_for_error($value->{$_}) } keys %$value }
+          :                    $value
+          ;
   
   return $ret;
 }

--- a/lib/GraphQL/Execution.pm
+++ b/lib/GraphQL/Execution.pm
@@ -628,8 +628,6 @@ fun _get_argument_values(
 }
 
 fun _coerce_for_error(Any $value) {
-#   my ($value) = @_;
-  
   my $ret;
   
   if ( 'ARRAY' eq ref $value ) {

--- a/t/execution-variables.t
+++ b/t/execution-variables.t
@@ -154,6 +154,24 @@ subtest 'Handles objects and nullability', sub {
       );
     };
 
+    subtest 'errors on incorrect query input', sub {
+      my $doc = '
+        query q($id: String) {
+          fieldWithObjectInput(input: { id: $id })
+        }';
+      run_test(
+        [$schema, $doc],
+        {
+          data => { fieldWithObjectInput => undef },
+          errors => [ { message =>
+          q{Argument 'input' got invalid value {"id":"id"}.}
+          ."\n"."Expected 'TestInputObject'.\nIn field \"id\": Unknown field.\n",
+          locations => [{ column => 9, line => 4 }],
+          path => ['fieldWithObjectInput'],
+        } ] },
+      );
+    };
+
     subtest 'properly runs parseLiteral on complex scalar types', sub {
       my $doc = '{
         fieldWithObjectInput(input: {c: "foo", d: "SerializedValue"})

--- a/t/execution-variables.t
+++ b/t/execution-variables.t
@@ -154,24 +154,6 @@ subtest 'Handles objects and nullability', sub {
       );
     };
 
-    subtest 'errors on incorrect query input', sub {
-      my $doc = '
-        query q($id: String) {
-          fieldWithObjectInput(input: { id: $id })
-        }';
-      run_test(
-        [$schema, $doc],
-        {
-          data => { fieldWithObjectInput => undef },
-          errors => [ { message =>
-          q{Argument 'input' got invalid value {"id":"id"}.}
-          ."\n"."Expected 'TestInputObject'.\nIn field \"id\": Unknown field.\n",
-          locations => [{ column => 9, line => 4 }],
-          path => ['fieldWithObjectInput'],
-        } ] },
-      );
-    };
-
     subtest 'properly runs parseLiteral on complex scalar types', sub {
       my $doc = '{
         fieldWithObjectInput(input: {c: "foo", d: "SerializedValue"})


### PR DESCRIPTION
This is about handling incorrect query and/or variable input. Before this fix a client GraphQL request might return an error like this:

    Error: GraphQL error: cannot encode reference to scalar 'SCALAR(0x7f9ef27083c0)' unless the scalar is 0 or 1 at /cms/perl/lib/site_perl/5.26.1/GraphQL/Execution.pm line 617.

After the fix:

    Error: GraphQL error: Argument 'input' got invalid value {"foo":"foo"}.
