### PR TITLE
Fix field with non-nullable enum inputs

### DIFF
--- a/lib/GraphQL/Execution.pm
+++ b/lib/GraphQL/Execution.pm
@@ -565,7 +565,8 @@ fun _get_argument_values(
   my @enumfail = grep {
     ref($arg_nodes->{$_}) eq 'REF' and
     ref(${$arg_nodes->{$_}}) eq 'SCALAR' and
-    !$arg_defs->{$_}{type}->isa('GraphQL::Type::Enum')
+    !$arg_defs->{$_}{type}->isa('GraphQL::Type::Enum') and
+    !($arg_defs->{$_}{type}->isa('GraphQL::Type::NonNull') and $arg_defs->{$_}{type}->of->isa('GraphQL::Type::Enum'))
   } keys %$arg_defs;
   die GraphQL::Error->new(
     message => "Argument '$enumfail[0]' of type ".

--- a/t/execution-variables.t
+++ b/t/execution-variables.t
@@ -3,6 +3,7 @@ use GQLTest;
 
 BEGIN {
   use_ok( 'GraphQL::Type::Scalar', qw($String) ) || print "Bail out!\n";
+  use_ok( 'GraphQL::Type::Enum' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::InputObject' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::Object' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Schema' ) || print "Bail out!\n";
@@ -41,6 +42,11 @@ my $TestNestedInputObject = GraphQL::Type::InputObject->new(
   },
 );
 
+my $TestEnum = GraphQL::Type::Enum->new(
+  name => 'Enum',
+  values => { A => {}, B => {} },
+);
+
 my $TestType = GraphQL::Type::Object->new(
   name => 'TestType',
   fields => {
@@ -57,6 +63,11 @@ my $TestType = GraphQL::Type::Object->new(
     fieldWithNonNullableStringInput => {
       type => $String,
       args => { input => { type => $String->non_null } },
+      resolve => sub { $_[1]->{input} && $JSON->encode($_[1]->{input}) },
+    },
+    fieldWithNonNullableEnumInput => {
+      type => $String,
+      args => { input => { type => $TestEnum->non_null } },
       resolve => sub { $_[1]->{input} && $JSON->encode($_[1]->{input}) },
     },
     fieldWithDefaultArgumentValue => {
@@ -414,6 +425,16 @@ In method graphql_to_perl: parameter 1 ($item): found not an object.
       run_test(
         [$schema, $doc],
         { data => { fieldWithNonNullableStringInput => '"a"' } },
+      );
+    };
+
+    subtest 'allows non-nullable enum inputs to be set to a value directly', sub {
+      my $doc = '
+        { fieldWithNonNullableEnumInput(input: A) }
+      ';
+      run_test(
+        [$schema, $doc],
+        { data => { fieldWithNonNullableEnumInput => '"A"' } },
       );
     };
 

--- a/t/execution-variables.t
+++ b/t/execution-variables.t
@@ -3,7 +3,6 @@ use GQLTest;
 
 BEGIN {
   use_ok( 'GraphQL::Type::Scalar', qw($String) ) || print "Bail out!\n";
-  use_ok( 'GraphQL::Type::Enum' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::InputObject' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::Object' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Schema' ) || print "Bail out!\n";
@@ -42,11 +41,6 @@ my $TestNestedInputObject = GraphQL::Type::InputObject->new(
   },
 );
 
-my $TestEnum = GraphQL::Type::Enum->new(
-  name => 'Enum',
-  values => { A => {}, B => {} },
-);
-
 my $TestType = GraphQL::Type::Object->new(
   name => 'TestType',
   fields => {
@@ -63,11 +57,6 @@ my $TestType = GraphQL::Type::Object->new(
     fieldWithNonNullableStringInput => {
       type => $String,
       args => { input => { type => $String->non_null } },
-      resolve => sub { $_[1]->{input} && $JSON->encode($_[1]->{input}) },
-    },
-    fieldWithNonNullableEnumInput => {
-      type => $String,
-      args => { input => { type => $TestEnum->non_null } },
       resolve => sub { $_[1]->{input} && $JSON->encode($_[1]->{input}) },
     },
     fieldWithDefaultArgumentValue => {
@@ -425,16 +414,6 @@ In method graphql_to_perl: parameter 1 ($item): found not an object.
       run_test(
         [$schema, $doc],
         { data => { fieldWithNonNullableStringInput => '"a"' } },
-      );
-    };
-
-    subtest 'allows non-nullable enum inputs to be set to a value directly', sub {
-      my $doc = '
-        { fieldWithNonNullableEnumInput(input: A) }
-      ';
-      run_test(
-        [$schema, $doc],
-        { data => { fieldWithNonNullableEnumInput => '"A"' } },
       );
     };
 

--- a/t/perl.t
+++ b/t/perl.t
@@ -115,6 +115,26 @@ EOF
   );
 };
 
+subtest 'non-nullable enum as arg' => sub {
+  my $schema = GraphQL::Schema->from_doc(<<'EOF');
+enum E {
+  available
+  pending
+}
+
+type Query {
+  hello(arg: E!): String
+}
+EOF
+  run_test([
+    $schema, '{hello(arg: available)}', {
+      hello => sub { 'Hello, '.shift->{arg} }
+    }
+  ],
+    { data => { hello => 'Hello, available' } },
+  );
+};
+
 subtest 'arbitrary object as exception' => sub {
   {
     package MyException;


### PR DESCRIPTION
Cannot set enum value to non-nullable enum inputs of fields.

```perl
use strict;
use warnings;
use GraphQL::Schema;
use GraphQL::Execution qw(execute);
use Data::Dumper;
use JSON::MaybeXS;

my $schema = GraphQL::Schema->from_doc(<<'EOF');
enum AorB {
  A
  B
}
type Query {
  hello(input: AorB!): String
}
EOF

print JSON::MaybeXS->new->utf8->pretty->encode(execute(
    $schema,
    '{ hello(input: A) }',
    { hello => 'Hello world!' }
));
```

```json
{
   "errors" : [
      {
         "locations" : [
            {
               "line" : 1,
               "column" : 19
            }
         ],
         "path" : [
            "hello"
         ],
         "message" : "Argument 'input' of type 'AorB!' was given A which is enum value."
      }
   ],
   "data" : {
      "hello" : null
   }
}
```