### PR TITLE
parse SDL with directives

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -46,6 +46,7 @@ MANIFEST			This list of files
 README.md
 t/00-load.t
 t/00-report-prereqs.t
+t/directives.t
 t/execution-abstract.t
 t/execution-directives.t
 t/execution-execute.t

--- a/lib/GraphQL/Type/Library.pm
+++ b/lib/GraphQL/Type/Library.pm
@@ -113,6 +113,7 @@ declare "FieldMapInput", as Map[
     type => ConsumerOf['GraphQL::Role::Input'],
     default_value => Optional[Any],
     description => Optional[Str],
+    directives => Optional[Any]
   ]
 ] & ValuesMatchTypes['default_value', 'type' ];
 
@@ -263,6 +264,7 @@ declare "FieldMapOutput", as Map[
     subscribe => Optional[CodeRef],
     deprecation_reason => Optional[Str],
     description => Optional[Str],
+    directives => Optional[Any],
   ]
 ];
 

--- a/t/directives.t
+++ b/t/directives.t
@@ -1,0 +1,65 @@
+#!perl
+use 5.014;
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use GraphQL::Schema;
+use GraphQL::Execution 'execute';
+use GraphQL::Debug '_debug';
+
+ok my $doc = q<
+  directive @length(max: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+  directive @note(msg: Str) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION 
+    | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE
+    | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+  type Todo {
+    task: String! @length(max: 15)
+  }
+
+  type Query {
+    todos: [Todo]
+  }
+
+  type Mutation @length(max: 15) {
+    add_todo(task: String! @length(max: 15)): Todo
+  }
+
+  schema @note(msg: "Test") {
+    query: Query
+    mutation: Mutation
+  }
+
+>;
+
+ok my $schema = GraphQL::Schema->from_doc($doc);
+
+my @data = (
+  {task => 'Exercise!'},
+  {task => 'Bulk Milk'},
+  {task => 'Walk Dogs'},
+);
+
+my %root_value = (
+  todos => sub {
+    return \@data;
+  },
+  add_todo => sub {
+    _debug "adasdasdsdasdasdasdasd" x 10;
+    my ($args, $context, $info) = @_;
+    push @data, $args;
+    return $args;
+  }
+);
+
+my $q = q<
+  mutation {
+    add_todo(task: "milk1") { task }
+  }
+>;
+
+use Devel::Dwarn;
+Dwarn(execute($schema, $q, \%root_value));
+
+done_testing;

--- a/t/directives.t
+++ b/t/directives.t
@@ -59,7 +59,6 @@ my $q = q<
   }
 >;
 
-use Devel::Dwarn;
-Dwarn(execute($schema, $q, \%root_value));
+ok execute($schema, $q, \%root_value);
 
 done_testing;


### PR DESCRIPTION
I noticed that the type library wouldn't allow me to have directives in the SDL, this is a small change around that.  Again this is another PR to get commented started.  I'm not sure if:

directives => Optional[Any]

is what we want, I think that directives is an ArrayRef of HashRefs please let me know if that seems right to you

Also I couldn't really grok the test file naming convention so I just called it 'directives.t' please let me know how you think this fits in