### PR TITLE
Add extensions field to GraphQL::Error

### DIFF
--- a/lib/GraphQL/Error.pm
+++ b/lib/GraphQL/Error.pm
@@ -61,6 +61,15 @@ the path from the top operation (being either fields, or a List offset).
 
 has path => (is => 'ro', isa => ArrayRef[StrNameValid | Int]);
 
+=head2 extensions
+
+Hash-ref of L<GraphQL::Type::Library/JSONable>s providing additional
+information.
+
+=cut
+
+has extensions => (is => 'ro', isa => Optional[HashRef[JSONable]]);
+
 =head1 METHODS
 
 =head2 is

--- a/lib/GraphQL/Type/Library.pm
+++ b/lib/GraphQL/Type/Library.pm
@@ -334,9 +334,19 @@ declare "DocumentLocation",
     column => Int,
   ];
 
+=head2 JSONable
+
+A value that will be JSON-able.
+
+=cut
+
+declare "JSONable",
+  as Any,
+    where { $JSON->encode($_); 1 };
+
 =head2 ErrorResult
 
-Hash-ref that has keys C<message>, C<location>, C<path>.
+Hash-ref that has keys C<message>, C<location>, C<path>, C<extensions>.
 
 =cut
 
@@ -345,6 +355,7 @@ declare "ErrorResult",
     message => Str,
     path => Optional[ArrayRef[Str]],
     locations => Optional[ArrayRef[DocumentLocation]],
+    extensions => Optional[HashRef[JSONable]],
   ];
 
 =head2 ExecutionResult
@@ -358,10 +369,6 @@ values are either further hashes, array-refs, or scalars. It will be
 JSON-able.
 
 =cut
-
-declare "JSONable",
-  as Any,
-  where { $JSON->encode($_); 1 };
 
 declare "ExecutionResult",
   as Dict[


### PR DESCRIPTION
The `extensions` field is allowed by the GraphQL specification.

> GraphQL services may provide an additional entry to errors with key extensions. This entry, if set, must have a map as its value. This entry is reserved for implementors to add additional information to errors however they see fit, and there are no additional restrictions on its contents.
https://graphql.github.io/graphql-spec/June2018/#sec-Errors
