### PR TITLE
Support field directives

### DIFF
--- a/lib/GraphQL/Role/FieldsEither.pm
+++ b/lib/GraphQL/Role/FieldsEither.pm
@@ -103,6 +103,13 @@ method _make_fieldtuples(
     $line .= ' = ' . $JSON_noutf8->encode(
       $type->perl_to_graphql($field->{default_value})
     ) if exists $field->{default_value};
+    my @directives = map {
+      my $args = $_->{arguments};
+      my @argtuples = map { $_ . ': ' . $JSON_noutf8->encode($args->{$_}) } keys %$args;
+      my $directive = '@' . $_->{name};
+      @argtuples ? $directive . '(' . join(', ', @argtuples) . ')' : $directive;
+    } @{ $field->{directives} };
+    $line .= join(' ', ('', @directives)) if exists $field->{directives};
     [
       $self->_to_doc_field_deprecate($line, $field),
       $self->_description_doc_lines($field->{description}),

--- a/lib/GraphQL/Type/Library.pm
+++ b/lib/GraphQL/Type/Library.pm
@@ -112,6 +112,7 @@ declare "FieldMapInput", as Map[
   Dict[
     type => ConsumerOf['GraphQL::Role::Input'],
     default_value => Optional[Any],
+    directives => Optional[ArrayRef[HashRef]],
     description => Optional[Str],
   ]
 ] & ValuesMatchTypes['default_value', 'type' ];
@@ -261,6 +262,7 @@ declare "FieldMapOutput", as Map[
     args => Optional[FieldMapInput],
     resolve => Optional[CodeRef],
     subscribe => Optional[CodeRef],
+    directives => Optional[ArrayRef],
     deprecation_reason => Optional[Str],
     description => Optional[Str],
   ]

--- a/t/type-definition.t
+++ b/t/type-definition.t
@@ -181,6 +181,71 @@ subtest 'defines an object type with deprecated field', sub {
   };
 };
 
+subtest 'define definitions including fields with directives', sub {
+  my $TypeWithFieldWithDirective = GraphQL::Type::Object->new(
+    name => 'foo',
+    fields => {
+      bar => {
+        type => $String,
+        directives => [
+          {
+            name => 'directive',
+            arguments => { arg => 'value' },
+          }
+        ]
+      }
+    },
+  );
+  is_deeply $TypeWithFieldWithDirective->fields->{bar}->{directives}, [
+    {
+      name => 'directive',
+      arguments => { arg => 'value' },
+    }
+  ];
+
+  my $InterfaceWithFieldWithDirective = GraphQL::Type::Interface->new(
+    name => 'foo',
+    fields => {
+      bar => {
+        type => $String,
+        directives => [
+          {
+            name => 'directive',
+            arguments => { arg => 'value' },
+          }
+        ]
+      }
+    },
+  );
+  is_deeply $InterfaceWithFieldWithDirective->fields->{bar}->{directives}, [
+    {
+      name => 'directive',
+      arguments => { arg => 'value' },
+    }
+  ];
+
+  my $InputWithFieldWithDirective = GraphQL::Type::InputObject->new(
+    name => 'foo',
+    fields => {
+      bar => {
+        type => $String,
+        directives => [
+          {
+            name => 'directive',
+            arguments => { arg => 'value' },
+          }
+        ]
+      }
+    },
+  );
+  is_deeply $InputWithFieldWithDirective->fields->{bar}->{directives}, [
+    {
+      name => 'directive',
+      arguments => { arg => 'value' },
+    }
+  ];
+};
+
 subtest 'includes nested input objects in the map', sub {
   my $NestedInputObject = GraphQL::Type::InputObject->new(
     name => 'NestedInputObject',

--- a/t/util-buildschema.t
+++ b/t/util-buildschema.t
@@ -473,6 +473,24 @@ EOF
   is(GraphQL::Schema->from_doc($doc)->to_doc, $doc);
 };
 
+subtest 'Supports directives on field' => sub {
+  my $doc = <<'EOF';
+input DirectiveInput {
+  field: String @directive
+}
+
+interface DirectiveInterface {
+  field: String @directive
+}
+
+type Query {
+  field1: String @directive1
+  field2: Int @directive2(arg: true)
+}
+EOF
+  is(GraphQL::Schema->from_doc($doc)->to_doc, $doc);
+};
+
 # except it doesn't - just round-trip
 subtest 'Correctly assign AST nodes' => sub {
   my $doc = <<'EOF';


### PR DESCRIPTION
The [specification](https://graphql.github.io/graphql-spec/June2018/) says type language supports directives for fields of ObjectTypeDefinition, InterfaceTypeDefinition, and InputTypeObjectDefinition. 

This feature is useful to implement a tool like [graphql-cost-analysis](https://github.com/pa-bru/graphql-cost-analysis). We actually intend to implement such tool in Perl for production use.