### PR TITLE
Allow serialising already-blessed bools

### DIFF
--- a/lib/GraphQL/Type/Scalar.pm
+++ b/lib/GraphQL/Type/Scalar.pm
@@ -176,7 +176,7 @@ our $Boolean = GraphQL::Type::Scalar->new(
   name => 'Boolean',
   description =>
     'The `Boolean` scalar type represents `true` or `false`.',
-  serialize => _leave_undef(sub { !is_Bool($_[0]) and !is_bool($_[0]) and die "Not a out Boolean.\n"; $_[0] ? JSON->true : JSON->false }),
+  serialize => _leave_undef(sub { !is_Bool($_[0]) and !is_bool($_[0]) and die "Not a Boolean.\n"; $_[0] ? JSON->true : JSON->false }),
   parse_value => _leave_undef(sub { !is_bool($_[0]) and die "Not a Boolean.\n"; $_[0]+0 }),
 );
 

--- a/lib/GraphQL/Type/Scalar.pm
+++ b/lib/GraphQL/Type/Scalar.pm
@@ -176,7 +176,7 @@ our $Boolean = GraphQL::Type::Scalar->new(
   name => 'Boolean',
   description =>
     'The `Boolean` scalar type represents `true` or `false`.',
-  serialize => _leave_undef(sub { !is_Bool($_[0]) and die "Not a Boolean.\n"; $_[0] ? JSON->true : JSON->false }),
+  serialize => _leave_undef(sub { !is_Bool($_[0]) and !is_bool($_[0]) and die "Not a out Boolean.\n"; $_[0] ? JSON->true : JSON->false }),
   parse_value => _leave_undef(sub { !is_bool($_[0]) and die "Not a Boolean.\n"; $_[0]+0 }),
 );
 

--- a/t/perl.t
+++ b/t/perl.t
@@ -348,6 +348,7 @@ subtest 'test Scalar methods' => sub {
   throws_ok { $scalar->parse_value->('string') } qr{Fake}, 'fake parse_value';
   is $scalar->to_doc, qq{"d"\nscalar s\n}, 'to_doc';
   is $Boolean->serialize->(1), 1, 'Boolean serialize';
+  is $Boolean->serialize->(JSON->true), 1, 'Boolean serialize blessed';
   is $Boolean->parse_value->(JSON->true), 1, 'Boolean parse_value';
   for my $type ($Int, $Float, $String, $Boolean) {
     is $type->$_->(undef), undef, join(' ', $type->name, $_, 'null')


### PR DESCRIPTION
https://github.com/graphql-perl/graphql-perl/blob/48ba8eba1aca82b342a57b97c240f17bc4dede6a/lib/GraphQL/Type/Scalar.pm#L179

I'm trying to wire up a method to a GraphQL field that returns already-blessed `JSON::PP::Boolean` instances which was tripping up ☝️ this check.

This PR just allows serialising objects that pass the `JSON::is_bool` test