### PR TITLE
Handle unquoted enum values as defaults

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 - type-checking now only when Devel::StrictMode STRICT (#31) - thanks @ccakes
+- can give default values to enums in queries (#33) - thanks @ccakes
 
 0.46 2021-01-27
 - PromiseCode example to interoperate with Promises - thanks @hitode909

--- a/lib/GraphQL/Type/Enum.pm
+++ b/lib/GraphQL/Type/Enum.pm
@@ -109,9 +109,10 @@ method is_valid(Any $item) :ReturnType(Bool) {
   !!$self->_value2name->{$item};
 }
 
-method graphql_to_perl(Maybe[Str] $item) {
+method graphql_to_perl(Maybe[Str | ScalarRef] $item) {
   DEBUG and _debug('graphql_to_perl', $item, $self->_name2value);
   return undef if !defined $item;
+  $item = $$$item if ref($item) eq 'REF'; # Handle unquoted enum values
   $self->_name2value->{$item} // die "Expected type '@{[$self->to_string]}', found $item.\n";
 }
 


### PR DESCRIPTION
A much smaller PR this time 😁 

Discovered while running a validator over our GQL queries, I have enums for defining ordering and have been setting defaults like so

```graphql
# Schema
enum FooOrderBy {
  ID_ASC
  ID_DESC
  NAME_ASC
  NAME_DESC
}

type Query {
  allFoos(filter: FooFilter, first: Int, last: Int, before: Cursor, after: Cursor, orderBy: FooOrderBy): FooConnection
}

# Query
query getFoos(
  $filter: FooFilter,
  $first: Int,
  $after: Cursor,
  $orderBy: FooOrderBy = "NAME_ASC"
) {
   # ...
}
```

This works fine but apparently is invalid GraphQL - the default enum value should be unquoted. GraphQL.pm throws an error when I try, so this PR (badly) fixes that and adds test coverage for both quoted and unquoted cases.