### PR TITLE
Only push MaybeTypeCheck onto @ISA of direct importers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- type-checking only on direct MaybeTypeCheck use (#35) - thanks @ccakes
+
 0.48 2021-02-05
 - require Import::Into 1.002003 as we depend on module-loading
 

--- a/lib/GraphQL/MaybeTypeCheck.pm
+++ b/lib/GraphQL/MaybeTypeCheck.pm
@@ -60,16 +60,12 @@ sub ReturnType : ATTR(CODE) {
 }
 
 sub import {
+  return unless $_[0] eq __PACKAGE__;
   my $caller = caller;
-
-  # Here we push ourselves onto @ISA of the caller so they use our ReturnType
-  # attribute which conditionally wraps the target sub depending on whetther
-  # strict mode is enabled or not.
   {
     no strict 'refs';
     push @{"${caller}::ISA"}, __PACKAGE__;
   }
-
   if (STRICT) {
     Function::Parameters->import::into($caller, ':strict');
     require Return::Type;

--- a/t/perl.t
+++ b/t/perl.t
@@ -664,15 +664,13 @@ subtest 'asynciterator' => sub {
   throws_ok { $ai->publish(6) } qr{closed}, 'publish to closed off';
 };
 
-subtest "sane class heirarchy" => sub {
+subtest "sane class hierarchy" => sub {
   package OtherNamespace::Foo {
     use GraphQL::Type::Object;
   }
-
   package OtherNamespace::Bar {
     use GraphQL::MaybeTypeCheck;
   }
-
   is_deeply \@OtherNamespace::Foo::ISA, [], "OtherNamespace::Foo does not inherit MaybeTypeCheck";
   is_deeply \@OtherNamespace::Bar::ISA, ['GraphQL::MaybeTypeCheck'], "OtherNamespace::Bar does inherit MaybeTypeCheck";
 };

--- a/t/perl.t
+++ b/t/perl.t
@@ -664,4 +664,17 @@ subtest 'asynciterator' => sub {
   throws_ok { $ai->publish(6) } qr{closed}, 'publish to closed off';
 };
 
+subtest "sane class heirarchy" => sub {
+  package OtherNamespace::Foo {
+    use GraphQL::Type::Object;
+  }
+
+  package OtherNamespace::Bar {
+    use GraphQL::MaybeTypeCheck;
+  }
+
+  is_deeply \@OtherNamespace::Foo::ISA, [], "OtherNamespace::Foo does not inherit MaybeTypeCheck";
+  is_deeply \@OtherNamespace::Bar::ISA, ['GraphQL::MaybeTypeCheck'], "OtherNamespace::Bar does inherit MaybeTypeCheck";
+};
+
 done_testing;


### PR DESCRIPTION
Closes #34 

This change makes `GraphQL::MaybeTypeCheck->import` a no-op if it's being called from a package that inherited it.

~The test files don't work as I hoped, trying to enable/disable `Devel::StrictMode` in BEGIN blocks isn't working. Any ideas there?~ I've got this fixed