### PR TITLE
Provide SDL keyword mapping also in from_doc

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- from_doc accepts kind2class to override SDL keyword - thanks @mangano-ito
+
 0.50 2021-04-08
 - Scalar.parse_value was wrong for Boolean - thanks @ccakes for report
 

--- a/lib/GraphQL/Schema.pm
+++ b/lib/GraphQL/Schema.pm
@@ -274,7 +274,7 @@ method from_ast(
   $schema;
 }
 
-=head2 from_doc($doc)
+=head2 from_doc($doc[, \%kind2class])
 
 Class method. Takes text that is a Schema Definition Language (SDL) (aka
 Interface Definition Language) document and returns a schema object. Will
@@ -283,12 +283,18 @@ not be a complete schema since it will have only default resolvers.
 As of v0.32, this accepts both old-style "meaningful comments" and
 new-style string values, as field or type descriptions.
 
+If C<\%kind2class> is given, it will override the default
+mapping of SDL keywords to Perl classes. This is probably most
+useful for L<GraphQL::Type::Object>. The default is available as
+C<%GraphQL::Schema::KIND2CLASS>.
+
 =cut
 
 method from_doc(
   Str $doc,
+  HashRef $kind2class = \%KIND2CLASS,
 ) :ReturnType(InstanceOf[__PACKAGE__]) {
-  $self->from_ast(parse($doc));
+  $self->from_ast(parse($doc), $kind2class);
 }
 
 =head2 to_doc($doc)


### PR DESCRIPTION
We cannot provide SDL keyword overrides when building schema from document with `from_doc` now.

This change introduces an optional argument `%kind2class` to inject the same override mapping as in `from_ast`.
I believe this doesn't affect the default behavior without that argument.

I need my own `union`s (or `interface`s) resolving concrete types by the application specific rules.
The keyword mapping helps overriding the default implementation so that I get these kinds of templated `union`s.
That's why I need the option even in the `from_doc` way.

Thank you,