### PR TITLE
No auto-inclusion of `DateTime`

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- not always load DateTime type - thanks @mangano-ito
+
 0.51 2021-07-04
 - from_doc accepts kind2class to override SDL keyword - thanks @mangano-ito
 

--- a/lib/GraphQL/Schema.pm
+++ b/lib/GraphQL/Schema.pm
@@ -10,7 +10,6 @@ use GraphQL::MaybeTypeCheck;
 use GraphQL::Debug qw(_debug);
 use GraphQL::Directive;
 use GraphQL::Introspection qw($SCHEMA_META_TYPE);
-use GraphQL::Plugin::Type::DateTime;
 use GraphQL::Language::Parser qw(parse);
 use GraphQL::Plugin::Type;
 use Module::Runtime qw(require_module);
@@ -70,8 +69,8 @@ has subscription => (is => 'ro', isa => InstanceOf['GraphQL::Type::Object']);
 =head2 types
 
 Defaults to the types returned by L<GraphQL::Plugin::Type/registered>.
-Note that this includes the non-standard C<DateTime> type, and the
-standard scalar types, always loaded by L<GraphQL::Type::Scalar>. If you
+Note that this includes the standard scalar types always loaded by
+L<GraphQL::Type::Scalar>. If you
 wish to supply an overriding value for this attribute, bear that in mind.
 
 =cut

--- a/t/perl.t
+++ b/t/perl.t
@@ -7,6 +7,7 @@ my $JSON = JSON::MaybeXS->new->allow_nonref->canonical;
 
 use GraphQL::Schema;
 use GraphQL::Execution qw(execute);
+use GraphQL::Plugin::Type::DateTime;
 use GraphQL::Subscription qw(subscribe);
 use GraphQL::Type::Scalar qw($Int $Float $String $Boolean);
 use GraphQL::Type::InputObject;

--- a/t/type-definition.t
+++ b/t/type-definition.t
@@ -5,6 +5,7 @@ use Test::More;
 use Test::Exception;
 
 BEGIN {
+  use_ok( 'GraphQL::Plugin::Type::DateTime' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::Interface' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::Object' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::Enum' ) || print "Bail out!\n";

--- a/t/type-introspection.t
+++ b/t/type-introspection.t
@@ -4,6 +4,7 @@ use GQLTest;
 my $JSON = JSON::MaybeXS->new->allow_nonref;
 
 BEGIN {
+  use_ok( 'GraphQL::Plugin::Type::DateTime' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Schema' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::Object' ) || print "Bail out!\n";
   use_ok( 'GraphQL::Type::InputObject' ) || print "Bail out!\n";


### PR DESCRIPTION
`GraphQL::Schema` introduces a builtin `DateTime` custom scalar type automatically.
The type is implicitly included so may occurs type-conflict and/or schema incompatibility.

This change simply drops import of it so that it's no longer enabled by default.
Those who need it may want to add `use` in theirs codes to opt it in again.

---

resolves #38 