### PR TITLE
Coerce integers into Strings

### DIFF
--- a/lib/GraphQL/Type/Scalar.pm
+++ b/lib/GraphQL/Type/Scalar.pm
@@ -163,7 +163,7 @@ our $String = GraphQL::Type::Scalar->new(
     'The `String` scalar type represents textual data, represented as UTF-8 ' .
     'character sequences. The String type is most often used by GraphQL to ' .
     'represent free-form human-readable text.',
-  serialize => _leave_undef(sub { !is_Str($_[0]) and die "Not a String.\n"; $_[0] }),
+  serialize => _leave_undef(sub { !is_Str($_[0]) and die "Not a String.\n"; $_[0].'' }),
   parse_value => _leave_undef(sub { !is_Str($_[0]) and die "Not a String.\n"; $_[0] }),
 );
 

--- a/lib/GraphQL/Type/Scalar.pm
+++ b/lib/GraphQL/Type/Scalar.pm
@@ -191,7 +191,7 @@ our $ID = GraphQL::Type::Scalar->new(
     'response as a String; however, it is not intended to be human-readable. ' .
     'When expected as an input type, any string (such as `"4"`) or integer ' .
     '(such as `4`) input value will be accepted as an ID.',
-  serialize => _leave_undef(sub { Str->(@_); $_[0] }),
+  serialize => _leave_undef(sub { Str->(@_); $_[0].'' }),
   parse_value => _leave_undef(sub { Str->(@_); $_[0] }),
 );
 

--- a/t/perl.t
+++ b/t/perl.t
@@ -9,7 +9,7 @@ use GraphQL::Schema;
 use GraphQL::Execution qw(execute);
 use GraphQL::Plugin::Type::DateTime;
 use GraphQL::Subscription qw(subscribe);
-use GraphQL::Type::Scalar qw($Int $Float $String $Boolean);
+use GraphQL::Type::Scalar qw($Int $Float $String $Boolean $ID);
 use GraphQL::Type::InputObject;
 use GraphQL::Type::Object;
 use GraphQL::Type::Interface;
@@ -356,6 +356,9 @@ subtest 'test Scalar methods' => sub {
     is $type->$_->(undef), undef, join(' ', $type->name, $_, 'null')
       for qw(serialize parse_value);
   }
+
+  is $JSON->encode( $String->serialize->(1 + 1) ), '"2"', "String serialize a number json encodes as string";
+  is $JSON->encode( $ID->serialize->(1 + 1) ), '"2"', "String serialize a ID json encodes as string"
 };
 
 subtest 'exercise __type root field more'=> sub {


### PR DESCRIPTION
Arrays of strings were not treating integers as strings in the JSON response. Appending an empty string coerces the value to a string.