### PR TITLE
fix graphql-js url

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The above is from [the sample Dancer 2 applet](https://github.com/graphql-perl/s
 # DESCRIPTION
 
 This module is a port of the GraphQL reference implementation,
-[graphql-js](https://github.com/graphql-js/graphql-js), to Perl 5.
+[graphql-js](https://github.com/graphql/graphql-js), to Perl 5.
 
 It now supports Promises, allowing asynchronous operation. See
 [Mojolicious::Plugin::GraphQL](https://metacpan.org/pod/Mojolicious%3A%3APlugin%3A%3AGraphQL) for an example of how to take advantage

--- a/lib/GraphQL.pm
+++ b/lib/GraphQL.pm
@@ -53,7 +53,7 @@ The above is from L<the sample Dancer 2 applet|https://github.com/graphql-perl/s
 =head1 DESCRIPTION
 
 This module is a port of the GraphQL reference implementation,
-L<graphql-js|https://github.com/graphql-js/graphql-js>, to Perl 5.
+L<graphql-js|https://github.com/graphql/graphql-js>, to Perl 5.
 
 It now supports Promises, allowing asynchronous operation. See
 L<Mojolicious::Plugin::GraphQL> for an example of how to take advantage


### PR DESCRIPTION
https://github.com/graphql-js/graphql-js was 404.
I think you probably meant https://github.com/graphql/graphql-js, so I fixed it.